### PR TITLE
Fix: apply remaining Qodo v2 robustness and portability updates

### DIFF
--- a/comprehensive_experiment_analysis.py
+++ b/comprehensive_experiment_analysis.py
@@ -6,11 +6,15 @@ Based on actual experiment results structure
 
 import argparse
 import asyncio
+import getpass
+import hashlib
 import json
+import logging
+import os
 import shutil
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TypeAlias
 
@@ -19,6 +23,10 @@ from fractalsemantics.experiment_runner import ExperimentRunner
 JsonScalar: TypeAlias = str | int | float | bool | None
 JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
 JsonObject: TypeAlias = dict[str, JsonValue]
+
+_audit_logger = logging.getLogger("fractalsemantics.audit")
+if not _audit_logger.handlers:
+    _audit_logger.addHandler(logging.NullHandler())
 
 
 def _parse_cli_args(argv: list[str] | None = None) -> tuple[argparse.Namespace, list[str]]:
@@ -74,19 +82,129 @@ def _should_archive_before_wipe() -> bool:
         print("Please answer 'y' or 'n'.")
 
 
+def _write_audit_log(
+    action: str,
+    outcome: str,
+    details: JsonObject,
+    audit_log_path: Path,
+) -> None:
+    """Append a structured JSON-L audit entry recording a critical file-system action.
+
+    Each entry captures the actor, timestamp, action, and outcome so that the
+    wipe/archive workflow is fully traceable for scientific-integrity audits.
+    """
+    try:
+        actor = getpass.getuser()
+    except Exception:
+        actor = "unknown"
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "actor": actor,
+        "action": action,
+        "outcome": outcome,
+        "details": details,
+    }
+    try:
+        audit_log_path.parent.mkdir(parents=True, exist_ok=True)
+        with audit_log_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry) + "\n")
+    except OSError as exc:
+        _audit_logger.warning("Could not write audit log entry: %s", exc)
+
+
+def _write_archive_manifest(archive_dir: Path, moved: list[dict]) -> None:
+    """Write a manifest.json to *archive_dir* documenting all archived files.
+
+    Each entry includes the original path, destination path, file size in bytes,
+    and a SHA-256 content hash (for files) to support scientific reproducibility
+    and data-provenance verification.
+    """
+    manifest = {
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "archive_dir": str(archive_dir),
+        "entries": moved,
+    }
+    manifest_path = archive_dir / "manifest.json"
+    try:
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        with manifest_path.open("w", encoding="utf-8") as fh:
+            json.dump(manifest, fh, indent=2)
+    except OSError as exc:
+        _audit_logger.warning("Could not write archive manifest to %s: %s", manifest_path, exc)
+
+
+def _file_sha256(path: Path) -> str:
+    """Return the hex SHA-256 digest of a file's contents."""
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
 def _archive_paths(paths: list[Path], results_dir: Path, project_root: Path) -> Path | None:
     """Archive paths under results/archive/<timestamp>/ preserving results-relative structure."""
     if not paths:
         return None
 
-    archive_dir = project_root / "results" / "archive" / datetime.now().strftime("%Y%m%d_%H%M%S")
+    archive_dir = project_root / "results" / "archive" / datetime.now().strftime("%Y%m%d_%H%M%S_%f")
     archive_dir.mkdir(parents=True, exist_ok=True)
+    audit_log_path = project_root / "results" / "archive" / "audit.jsonl"
+    hash_enabled = os.environ.get("FRACTALSEMANTICS_ARCHIVE_HASH", "true").strip().lower() in {
+        "1", "true", "yes", "on"
+    }
+    moved: list[dict] = []
     for path in paths:
         if not path.exists():
             continue
-        destination = archive_dir / path.relative_to(results_dir)
+        try:
+            relative_path = path.relative_to(results_dir)
+        except ValueError:
+            relative_path = Path(path.name)
+        destination = archive_dir / relative_path
         destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(path), str(destination))
+        size = None
+        sha256 = None
+        if path.is_file():
+            try:
+                size = path.stat().st_size
+            except OSError as exc:
+                _audit_logger.warning("Could not stat file %s before archive move: %s", path, exc)
+            if hash_enabled:
+                try:
+                    sha256 = _file_sha256(path)
+                except OSError as exc:
+                    _audit_logger.warning("Failed to compute SHA-256 for %s: %s", path, exc)
+
+        try:
+            shutil.move(str(path), str(destination))
+        except OSError as exc:
+            _write_audit_log(
+                action="archive_move",
+                outcome="failure",
+                details={
+                    "source": str(path),
+                    "destination": str(destination),
+                    "error": str(exc),
+                },
+                audit_log_path=audit_log_path,
+            )
+            _audit_logger.warning("Failed to move %s to %s: %s", path, destination, exc)
+            continue
+
+        entry: dict = {"source": str(path), "destination": str(destination)}
+        if size is not None:
+            entry["size_bytes"] = size
+        if sha256 is not None:
+            entry["sha256"] = sha256
+        moved.append(entry)
+        _write_audit_log(
+            action="archive_move",
+            outcome="success",
+            details={"source": str(path), "destination": str(destination)},
+            audit_log_path=audit_log_path,
+        )
+    _write_archive_manifest(archive_dir, moved)
     return archive_dir
 
 
@@ -117,22 +235,47 @@ def _wipe_archive_store(project_root: Path) -> None:
 def _wipe_history(project_root: Path, force_delete: bool) -> None:
     """Wipe history paths, optionally archiving first."""
     targets = _collect_history_paths(project_root)
+    audit_log_path = project_root / "results" / "archive" / "audit.jsonl"
     if not targets:
         print("No history files found to wipe.")
         return
 
     if force_delete:
         deleted = _delete_paths(targets)
+        _write_audit_log(
+            action="wipe_history_force_delete",
+            outcome="success",
+            details={"deleted_count": deleted, "paths": [str(t) for t in targets]},
+            audit_log_path=audit_log_path,
+        )
         print(f"Wipe complete (force delete): removed {deleted} entries.")
         return
 
     if _should_archive_before_wipe():
         archive_dir = _archive_paths(targets, project_root / "results", project_root)
         if archive_dir:
-            print(f"Wipe complete (archived): moved history to {archive_dir}")
+            manifest_path = archive_dir / "manifest.json"
+            total_bytes = 0
+            if manifest_path.exists():
+                manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
+                total_bytes = sum(
+                    e.get("size_bytes", 0)
+                    for e in manifest_data.get("entries", [])
+                    if isinstance(e.get("size_bytes"), int)
+                )
+            print(
+                f"Wipe complete (archived): moved history to {archive_dir}"
+                + (f" ({total_bytes:,} bytes)" if total_bytes else "")
+            )
         return
 
     deleted = _delete_paths(targets)
+    _write_audit_log(
+        action="wipe_history_delete",
+        outcome="success",
+        details={"deleted_count": deleted, "paths": [str(t) for t in targets]},
+        audit_log_path=audit_log_path,
+    )
     print(f"Wipe complete (delete): removed {deleted} entries.")
 
 
@@ -155,6 +298,36 @@ def _exp_name_to_experiment_id(exp_name: str) -> str | None:
     if prefix.startswith("exp") and len(prefix) == 5 and prefix[3:].isdigit():
         return f"EXP-{prefix[3:]}"
     return None
+
+
+def _extract_numeric_collision_rates(collision_rates: object) -> list[float]:
+    """Extract a list of numeric collision-rate floats from various container shapes.
+
+    Accepts a ``dict`` (values are the rates), a ``list``/``tuple`` (items are
+    the rates), or a bare scalar.  Non-numeric values are silently skipped so
+    that callers receive a clean list ready for statistical analysis without
+    risking an ``AttributeError`` when the data structure differs from the
+    expected dictionary shape.
+    """
+    candidates: list[object]
+    if isinstance(collision_rates, dict):
+        candidates = list(collision_rates.values())
+    elif isinstance(collision_rates, (list, tuple)):
+        candidates = list(collision_rates)
+    else:
+        candidates = [collision_rates]
+
+    result: list[float] = []
+    for value in candidates:
+        if isinstance(value, bool):
+            continue
+        if not isinstance(value, (int, float, str)):
+            continue
+        try:
+            result.append(float(value))
+        except (TypeError, ValueError):
+            continue
+    return result
 
 
 def _infer_technical_success_from_result(result: JsonObject) -> bool:
@@ -922,13 +1095,9 @@ def validate_exp11b(results: list[JsonObject]) -> tuple[bool, list[str], dict[st
 
     elif "collision_rates" in last_result:
         # Fallback to direct collision_rates field
-        raw_rates = last_result.get("collision_rates") or {}
-        numeric_rates: list[float] = []
-        for value in raw_rates.values():
-            try:
-                numeric_rates.append(float(value))
-            except (TypeError, ValueError):
-                continue
+        numeric_rates: list[float] = _extract_numeric_collision_rates(
+            last_result.get("collision_rates")
+        )
 
         if not numeric_rates:
             findings.append("✗ No valid collision rate values found")

--- a/fractalsemantics/exp14_atomic_fractal_mapping.py
+++ b/fractalsemantics/exp14_atomic_fractal_mapping.py
@@ -631,7 +631,7 @@ def run_atomic_fractal_mapping_experiment_v2(
         # Use all available elements from the periodic table
         elements_to_test = list(shell_data.keys())
     elif isinstance(elements_to_test, str):
-        elements_to_test = [elements_to_test]
+        elements_to_test = [e.strip() for e in elements_to_test.split(",") if e.strip()]
 
     print("\n" + "=" * 80)
     print("EXP-14 v2: SHELL-BASED ATOMIC-FRACTAL MAPPING")

--- a/fractalsemantics/experiment_runner.py
+++ b/fractalsemantics/experiment_runner.py
@@ -1941,6 +1941,7 @@ Full Traceback:
                 python_executable,
                 "-X",
                 "utf8",
+                "-u",
                 "-I",
                 "-m",
                 module_qualname,
@@ -2093,10 +2094,12 @@ Full Traceback:
                     normalized_full_output = self._normalize_output_save_language(combined_output)
                     deleted_artifacts = self._cleanup_softcopy_artifacts(normalized_full_output)
                     if deleted_artifacts:
-                        display_output += (
+                        combined_output += (
                             "\n[SOFTCOPY DISABLED] Persisted artifacts were removed after execution "
                             "(terminal output retained)."
                         )
+                        display_output = self._compress_output_for_display(combined_output, max_lines=OUTPUT_DISPLAY_MAX_LINES)
+                        display_output = self._normalize_output_save_language(display_output)
 
                 metrics: dict[str, Any] = {
                     "return_code": result_return_code,

--- a/gui_app.py
+++ b/gui_app.py
@@ -31,17 +31,26 @@ from plotly.subplots import make_subplots
 from streamlit_autorefresh import st_autorefresh
 
 # Add the fractalsemantics module to the path (must be done before local/package imports)
-sys.path.insert(0, str(Path(__file__).parent))
-sys.path.insert(0, str(Path(__file__).parent.parent))
+# Use append (not insert) so installed packages and the stdlib take precedence,
+# preventing import-hijacking via writable directories placed earlier on sys.path.
+_pkg_dir = str(Path(__file__).parent)
+_project_dir = str(Path(__file__).parent.parent)
+if _pkg_dir not in sys.path:
+    sys.path.append(_pkg_dir)
+if _project_dir not in sys.path:
+    sys.path.append(_project_dir)
 
-import gui_state_manager
-from fractalsemantics.experiment_runner import (
+import gui_state_manager  # noqa: E402
+from fractalsemantics.experiment_runner import (  # noqa: E402
     BatchRunResult,
     ExperimentResult,
     ExperimentRunner,
 )
-from fractalsemantics.progress_comm import clear_progress_file, read_progress_from_file
-from gui_state_manager import (
+from fractalsemantics.progress_comm import (  # noqa: E402
+    clear_progress_file,
+    read_progress_from_file,
+)
+from gui_state_manager import (  # noqa: E402
     cleanup_session_state,
     ensure_session_state_initialized,
     get_session_state_snapshot,

--- a/test_comprehensive_analysis_audit_helpers.py
+++ b/test_comprehensive_analysis_audit_helpers.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import comprehensive_experiment_analysis as cea
+
+
+def test_extract_numeric_collision_rates_handles_multiple_shapes() -> None:
+    assert cea._extract_numeric_collision_rates({"a": 1, "b": "2.5", "c": "x", "d": True}) == [1.0, 2.5]
+    assert cea._extract_numeric_collision_rates([0.1, "0.2", None, "x", False]) == [0.1, 0.2]
+    assert cea._extract_numeric_collision_rates(0.9) == [0.9]
+    assert cea._extract_numeric_collision_rates(None) == []
+
+
+def test_write_audit_log_jsonl_structure(tmp_path: Path) -> None:
+    audit_path = tmp_path / "archive" / "audit.jsonl"
+
+    cea._write_audit_log(
+        action="archive_move",
+        outcome="success",
+        details={"source": "a", "destination": "b"},
+        audit_log_path=audit_path,
+    )
+
+    lines = audit_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+
+    entry = json.loads(lines[0])
+    assert entry["action"] == "archive_move"
+    assert entry["outcome"] == "success"
+    assert isinstance(entry.get("timestamp"), str)
+    assert isinstance(entry.get("actor"), str)
+    assert entry["details"] == {"source": "a", "destination": "b"}
+
+
+def test_archive_paths_continues_when_hash_fails(tmp_path: Path, monkeypatch) -> None:
+    project_root = tmp_path
+    results_dir = project_root / "results"
+    results_dir.mkdir(parents=True)
+
+    src = results_dir / "example.json"
+    src.write_text('{"ok": true}', encoding="utf-8")
+
+    def _raise_hash(_path: Path) -> str:
+        raise OSError("hash failed")
+
+    monkeypatch.setattr(cea, "_file_sha256", _raise_hash)
+
+    archive_dir = cea._archive_paths([src], results_dir, project_root)
+
+    assert archive_dir is not None
+    archived_file = archive_dir / "example.json"
+    assert archived_file.exists()
+
+    manifest = json.loads((archive_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert len(manifest["entries"]) == 1
+    assert "sha256" not in manifest["entries"][0]
+
+
+def test_archive_paths_logs_move_failure(tmp_path: Path, monkeypatch) -> None:
+    project_root = tmp_path
+    results_dir = project_root / "results"
+    results_dir.mkdir(parents=True)
+
+    src = results_dir / "bad.json"
+    src.write_text("{}", encoding="utf-8")
+
+    original_move = cea.shutil.move
+
+    def _failing_move(src_path: str, dst_path: str):
+        if src_path.endswith("bad.json"):
+            raise OSError("move failed")
+        return original_move(src_path, dst_path)
+
+    monkeypatch.setattr(cea.shutil, "move", _failing_move)
+
+    archive_dir = cea._archive_paths([src], results_dir, project_root)
+
+    assert archive_dir is not None
+    assert src.exists()
+
+    audit_log = project_root / "results" / "archive" / "audit.jsonl"
+    assert audit_log.exists()
+    entries = [json.loads(line) for line in audit_log.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert any(e.get("outcome") == "failure" for e in entries)


### PR DESCRIPTION
### **User description**
## Summary
- fix isolated subprocess execution in xperiment_runner.py to run experiments as modules with project-root cwd
- fix softcopy cleanup to parse full normalized output (not compressed display output)
- harden comprehensive_experiment_analysis.py (alidate_exp02, alidate_exp11b, and archive path structure)
- move path setup before imports in gui_app.py for direct-run reliability
- improve EXP-14 robustness/style (lements_to_test guard, float threshold comparison, fallback stub formatting)

## Validation
- ruff check on touched files
- python fractalsemantics/experiment_runner.py EXP-14 --quick --format=text
- python comprehensive_experiment_analysis.py


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix subprocess execution to run experiments as modules with project-root cwd

- Harden experiment validation with robust data parsing and type safety

- Improve archive path handling with results-relative structure

- Fix EXP-14 robustness with guard conditions and threshold comparisons

- Reorder path setup before imports in gui_app.py for direct-run reliability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Subprocess Execution"] -->|"Module-based with project-root cwd"| B["Experiment Runner"]
  C["Data Validation"] -->|"Robust parsing & type safety"| D["Experiment Analysis"]
  E["Archive Paths"] -->|"Results-relative structure"| F["History Management"]
  G["EXP-14 Guards"] -->|"Element validation & threshold fix"| H["Atomic Fractal Mapping"]
  I["Path Setup"] -->|"Before imports"| J["GUI App"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>comprehensive_experiment_analysis.py</strong><dd><code>Harden archive handling and validation robustness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

comprehensive_experiment_analysis.py

<ul><li>Add <code>results_dir</code> parameter to <code>_archive_paths()</code> for results-relative <br>path structure<br> <li> Create archive directory with <code>mkdir(parents=True, exist_ok=True)</code> <br>before archiving<br> <li> Extract <code>scale</code> variable before use in <code>validate_exp02()</code> to avoid <br>repeated dict access<br> <li> Add robust numeric conversion with try-except in <code>validate_exp11b()</code> <br>collision rate parsing<br> <li> Handle empty collision rates gracefully with early return</ul>


</details>


  </td>
  <td><a href="https://github.com/Tiny-Walnut-Games/FractalSemantics/pull/4/files#diff-ee2985c010e11a29f812d2dda5f471fa2469318b8e95400599b74b446c73ddb2">+29/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>exp14_atomic_fractal_mapping.py</strong><dd><code>Improve EXP-14 robustness with guards and threshold fix</code>&nbsp; &nbsp; </dd></summary>
<hr>

fractalsemantics/exp14_atomic_fractal_mapping.py

<ul><li>Reformat fallback subprocess communication stubs with proper line <br>breaks<br> <li> Move <code>get_electron_shell_data()</code> call before conditional check<br> <li> Add guard condition <code>if not elements_to_test</code> to validate input <br>parameter<br> <li> Add string-to-list conversion for single element input with <br><code>isinstance()</code> check<br> <li> Fix threshold comparison from equality <code>==</code> to greater-than-or-equal <code>>=</code> <br>for exponential consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/Tiny-Walnut-Games/FractalSemantics/pull/4/files#diff-10526725c345d43502d6b8e8147f1ce36c827cef702b4f288a0b98dea2c084cf">+16/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>experiment_runner.py</strong><dd><code>Fix subprocess execution and softcopy artifact cleanup</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fractalsemantics/experiment_runner.py

<ul><li>Change subprocess execution from direct file path to module-based <br>invocation with <code>-m</code> flag<br> <li> Add module name qualification to ensure <code>fractalsemantics.</code> prefix for <br>module imports<br> <li> Change subprocess working directory from module parent to project root <br>for proper imports<br> <li> Fix softcopy cleanup to parse full normalized output instead of <br>compressed display output</ul>


</details>


  </td>
  <td><a href="https://github.com/Tiny-Walnut-Games/FractalSemantics/pull/4/files#diff-56301a9fe786401cf1a1a686a38644a1c5ab96e019e7a282a652976fe8d554db">+10/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gui_app.py</strong><dd><code>Reorder path setup before imports for reliability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gui_app.py

<ul><li>Move <code>sys.path</code> setup before all local and package imports for <br>direct-run reliability<br> <li> Reorder imports to place path configuration first, then local imports, <br>then package imports<br> <li> Add clarifying comment about path setup requirement</ul>


</details>


  </td>
  <td><a href="https://github.com/Tiny-Walnut-Games/FractalSemantics/pull/4/files#diff-85363f57b6663089c2d09573b7dfa9258453f5af0fa6404fd0d92492b5f1cb9c">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

